### PR TITLE
Implementing Makefile for easier manual build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+target/release/yari: libyari
+	cd yari-cli && cargo build -r
+
+libyari: yara
+	cd yari-sys && cargo build -r
+
+yara: yari-sys/yara/bootstrap.sh
+	cd yari-sys/yara && ./bootstrap.sh && CFLAGS="-fPIC ${CFLAGS}" ./configure --enable-debug --disable-shared --enable-static --enable-cuckoo --enable-magic --enable-dotnet --with-crypto && make clean && make
+
+yari-sys/yara/bootstrap.sh:
+	git submodule update --init --force
+
+clean:
+	cargo clean
+	@cd yari-sys/yara 2> /dev/null && make clean
+

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 target/release/yari: libyari
 	cd yari-cli && cargo build -r
 
-libyari: yara
+libyari: yari-sys/yara/yara
 	cd yari-sys && cargo build -r
 
-yara: yari-sys/yara/bootstrap.sh
+yari-sys/yara/yara: yari-sys/yara/bootstrap.sh
 	cd yari-sys/yara && ./bootstrap.sh && CFLAGS="-fPIC ${CFLAGS}" ./configure --enable-debug --disable-shared --enable-static --enable-cuckoo --enable-magic --enable-dotnet --with-crypto && make clean && make
 
 yari-sys/yara/bootstrap.sh:
 	git submodule update --init --force
 
+.PHONY: clean
 clean:
 	cargo clean
 	@cd yari-sys/yara 2> /dev/null && make clean
-


### PR DESCRIPTION
This PR introduces a small Makefile which might help other analysts to build the base project easier. This does not include building the Python module, but this could easily be included their, too.

Adding this as a draft as I had no chance to test it on linux, yet.