### PR TITLE
Implementing conditional compilation for linux aarch64

### DIFF
--- a/yari-sys/src/lib.rs
+++ b/yari-sys/src/lib.rs
@@ -796,12 +796,12 @@ impl Context {
 
         // Copy the string
         for (i, c) in s.bytes().enumerate() {
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
             unsafe {
                 (*sized_string).c_string.as_mut_ptr().add(i).write(c as u8)
             };
 
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
             unsafe {
                 (*sized_string).c_string.as_mut_ptr().add(i).write(c as i8)
             };
@@ -1029,7 +1029,7 @@ impl Context {
         for s in YrStringIterator::new(strings_table) {
             let mut prefix_ptr = prefix.as_ptr();
 
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
             unsafe {
                 let mut identifier = (*s).__bindgen_anon_3.identifier.offset(1);
                 while *identifier != '\0' as u8
@@ -1047,7 +1047,7 @@ impl Context {
                 }
             }
 
-            #[cfg(not(target_arch = "aarch64"))]
+            #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
             unsafe {
                 let mut identifier = (*s).__bindgen_anon_3.identifier.offset(1);
                 while *identifier != '\0' as i8


### PR DESCRIPTION
I had some issues compiling yari for linux aarch64 while testing the Makefile from #71 and therefore had to change some parts in lib.rs, e.g.:

```rust
for (i, c) in s.bytes().enumerate() {
    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
    unsafe {
        (*sized_string).c_string.as_mut_ptr().add(i).write(c as u8)
    };


    #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
    unsafe {
        (*sized_string).c_string.as_mut_ptr().add(i).write(c as i8)
    };
}
```

There seems to be a difference in the integer types expected under linux aarch64 and this change implements this only for this arch/os combination. All tests are passing.